### PR TITLE
Enhance observation of specific rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ Release Notes
 
 ## Next Version
 
-This version is focused on enhancing the scheduling of database notifications.
+This version enhances the scheduling of database notifications, and the tracking of specific database rows.
+
+
+## New
+
+- The tracking of requests that target specific rows, identified by their row ids, has been enhanced:
+    
+    In previous version of RxGRDB, tracking `Player.filter(key: 1)` would trigger change notifications for all changes to the players table.
+    
+    Now RxGRDB is able to precisely track the player of ID 1, and won't emit any notification for changes performed on other players.
 
 
 ## Fixed
@@ -14,6 +23,7 @@ This version is focused on enhancing the scheduling of database notifications.
 
 ### Breaking Changes
 
+- GRDB dependency has been bumped to v2.6.
 - Database observation scheduling used to be managed through raw dispatch queues. One now uses regular [RxSwift schedulers](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Schedulers.md). The `synchronizedStart` parameter has been renamed to `startImmediately` in order to reflect the fact that not all schedulers can start synchronously. See the updated [documentation](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#documentation) of RxGRDB reactive methods.
 - The `Diffable` protocol was ill-advised, and has been removed.
 - The `primaryKeySortedDiff` operator has been replaced by `PrimaryKeyDiffScanner` ([documentation](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#primarykeydiffscanner))

--- a/RxGRDB.podspec
+++ b/RxGRDB.podspec
@@ -18,12 +18,12 @@ Pod::Spec.new do |s|
   
   s.subspec 'default' do |ss|
     ss.source_files = 'RxGRDB/**/*.{h,swift}'
-    ss.dependency "GRDB.swift", "~> 2.0"
+    ss.dependency "GRDB.swift", "~> 2.6"
   end
   
   s.subspec 'GRDBCipher' do |ss|
     ss.source_files = 'RxGRDB/**/*.{h,swift}'
-    ss.dependency "GRDBCipher", "~> 2.0"
+    ss.dependency "GRDBCipher", "~> 2.6"
     ss.xcconfig = {
       'OTHER_SWIFT_FLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DUSING_SQLCIPHER',
       'OTHER_CFLAGS' => '$(inherited) -DSQLITE_HAS_CODEC -DUSING_SQLCIPHER',

--- a/RxGRDB.xcodeproj/project.pbxproj
+++ b/RxGRDB.xcodeproj/project.pbxproj
@@ -33,18 +33,18 @@
 		565029C41E9130F600615A2C /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565029C31E9130F600615A2C /* Support.swift */; };
 		565029C61E91318F00615A2C /* TypedRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565029C51E91318F00615A2C /* TypedRequestTests.swift */; };
 		565933EE1F0D72A400707571 /* ChangeToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565933ED1F0D72A400707571 /* ChangeToken.swift */; };
-		565934181F0E157800707571 /* SelectionInfoChangeTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* SelectionInfoChangeTokensObservable.swift */; };
-		565934191F0E157800707571 /* SelectionInfoChangeTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* SelectionInfoChangeTokensObservable.swift */; };
+		565934181F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift */; };
+		565934191F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift */; };
 		565934451F0EB6BC00707571 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */; };
 		565934461F0EB6BC00707571 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */; };
 		565934481F0F419600707571 /* ChangeTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934471F0F419600707571 /* ChangeTokenTests.swift */; };
 		565934491F0F419600707571 /* ChangeTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934471F0F419600707571 /* ChangeTokenTests.swift */; };
 		567043E21F66A7B9000A44BA /* RowValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567043E11F66A7B9000A44BA /* RowValueTests.swift */; };
 		567043E31F66A7B9000A44BA /* RowValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567043E11F66A7B9000A44BA /* RowValueTests.swift */; };
-		569E8511200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift */; };
-		569E8512200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift */; };
-		569E8514200A69D20028D1EC /* SelectionInfoChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* SelectionInfoChangeObserver.swift */; };
-		569E8515200A69D20028D1EC /* SelectionInfoChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* SelectionInfoChangeObserver.swift */; };
+		569E8511200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift */; };
+		569E8512200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift */; };
+		569E8514200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */; };
+		569E8515200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */; };
 		56DBA52F1F0BB02200C90A18 /* MapFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA52E1F0BB02200C90A18 /* MapFetch.swift */; };
 		56DBA5301F0BB02200C90A18 /* MapFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA52E1F0BB02200C90A18 /* MapFetch.swift */; };
 		56DBA5421F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA5411F0BF12B00C90A18 /* GRDB+Rx.swift */; };
@@ -320,12 +320,12 @@
 		565029C31E9130F600615A2C /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Support.swift; sourceTree = "<group>"; };
 		565029C51E91318F00615A2C /* TypedRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedRequestTests.swift; sourceTree = "<group>"; };
 		565933ED1F0D72A400707571 /* ChangeToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeToken.swift; sourceTree = "<group>"; };
-		565934171F0E157800707571 /* SelectionInfoChangeTokensObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionInfoChangeTokensObservable.swift; sourceTree = "<group>"; };
+		565934171F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionChangeTokensObservable.swift; sourceTree = "<group>"; };
 		565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseWriterTests.swift; sourceTree = "<group>"; };
 		565934471F0F419600707571 /* ChangeTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChangeTokenTests.swift; sourceTree = "<group>"; };
 		567043E11F66A7B9000A44BA /* RowValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowValueTests.swift; sourceTree = "<group>"; };
-		569E8510200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionInfoDatabaseObservable.swift; sourceTree = "<group>"; };
-		569E8513200A69D20028D1EC /* SelectionInfoChangeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionInfoChangeObserver.swift; sourceTree = "<group>"; };
+		569E8510200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionDatabaseObservable.swift; sourceTree = "<group>"; };
+		569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionChangeObserver.swift; sourceTree = "<group>"; };
 		56D65F031EF8F5740098466C /* RxGRDB.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = RxGRDB.podspec; sourceTree = "<group>"; };
 		56D65F261EF8F5C60098466C /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		56DBA52E1F0BB02200C90A18 /* MapFetch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapFetch.swift; sourceTree = "<group>"; };
@@ -500,9 +500,9 @@
 			children = (
 				561782561F655DAC00CEAA55 /* DiffSupport.swift */,
 				56DBA52E1F0BB02200C90A18 /* MapFetch.swift */,
-				565934171F0E157800707571 /* SelectionInfoChangeTokensObservable.swift */,
-				569E8510200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift */,
-				569E8513200A69D20028D1EC /* SelectionInfoChangeObserver.swift */,
+				565934171F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift */,
+				569E8510200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift */,
+				569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */,
 			);
 			name = Implementations;
 			sourceTree = "<group>";
@@ -922,12 +922,12 @@
 				5617825E1F6566EA00CEAA55 /* PrimaryKeyDiffScanner.swift in Sources */,
 				561782581F655DAC00CEAA55 /* DiffSupport.swift in Sources */,
 				560F92CC1E94DF830077EADF /* Request+Rx.swift in Sources */,
-				569E8512200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift in Sources */,
-				565934191F0E157800707571 /* SelectionInfoChangeTokensObservable.swift in Sources */,
+				569E8512200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */,
+				565934191F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift in Sources */,
 				562756591E963C1B0035B653 /* Result.swift in Sources */,
 				56DBA5681F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5431F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
-				569E8515200A69D20028D1EC /* SelectionInfoChangeObserver.swift in Sources */,
+				569E8515200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,
 				560F92CF1E94DF830077EADF /* TypedRequest+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -954,13 +954,13 @@
 				5617825D1F6566EA00CEAA55 /* PrimaryKeyDiffScanner.swift in Sources */,
 				561782571F655DAC00CEAA55 /* DiffSupport.swift in Sources */,
 				565029BA1E91265A00615A2C /* Request+Rx.swift in Sources */,
-				569E8511200A695A0028D1EC /* SelectionInfoDatabaseObservable.swift in Sources */,
+				569E8511200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */,
 				56DBA5671F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5421F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
 				565933EE1F0D72A400707571 /* ChangeToken.swift in Sources */,
 				565029B31E8FE12C00615A2C /* TypedRequest+Rx.swift in Sources */,
-				569E8514200A69D20028D1EC /* SelectionInfoChangeObserver.swift in Sources */,
-				565934181F0E157800707571 /* SelectionInfoChangeTokensObservable.swift in Sources */,
+				569E8514200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,
+				565934181F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR builds on top of #19 and https://github.com/groue/GRDB.swift/pull/288.

Until now, RxGRDB could only track tables and columns. This means that requests that track specific rows would in practice track *all rows*, and get undesired change notifications. For example:

```swift
// Track player of id 1
Player.filter(key: 1).rx
    .fetchOne(in: dbQueue)
    .subscribe(onNext: { player: Player? in print("Transaction impact on Player 1") })

// Undesired change notification:
try dbQueue.inDatabase { db
    // Insert player with id 2:
    try Player(id: 2, name: "foo").insert(db)
    // Prints "Transaction impact on Player 1" :-/
}
```

Since GRDB requests have learned about rowids, RxGRDB is now able to better track changes in specific rows:

```swift
try dbQueue.inDatabase { db
    // Insert player with id 2:
    try Player(id: 2, name: "foo").insert(db)
    // Prints nothing :-)
}
```

This optimization only applies to query interface requests like `Player.filter(key: 1)` or `Player.filter([1, 2, 3].contains(Column("id"))`. Raw SQL requests like `SELECT * FROM players WHERE id = 1` aren't concerned by this enhancement.

Let's now wait for #19 and the next GRDB release.