### PR TITLE
Bugfix for database values observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## Next Version
+
+Fixes a bug that would have [values observables](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#values-observables) fail to observe some database changes.
+
+
 ## 0.8.0
 
 Released January 18, 2018 &bull; [diff](https://github.com/RxSwiftCommunity/RxGRDB/compare/v0.7.0...v0.8.0)

--- a/RxGRDB.xcodeproj/project.pbxproj
+++ b/RxGRDB.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		562756581E963C1B0035B653 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562756571E963C1B0035B653 /* Result.swift */; };
 		562756591E963C1B0035B653 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562756571E963C1B0035B653 /* Result.swift */; };
 		562EA7F51F17A2A600FA528C /* ChangeToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565933ED1F0D72A400707571 /* ChangeToken.swift */; };
+		564E73AE203C99A7000C443C /* PThreadMutex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73AD203C99A7000C443C /* PThreadMutex.swift */; };
+		564E73AF203C99A7000C443C /* PThreadMutex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73AD203C99A7000C443C /* PThreadMutex.swift */; };
 		5650291F1E8FDF5600615A2C /* RxGRDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 565029151E8FDF5600615A2C /* RxGRDB.framework */; };
 		565029241E8FDF5600615A2C /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565029231E8FDF5600615A2C /* RequestTests.swift */; };
 		565029261E8FDF5600615A2C /* RxGRDB.h in Headers */ = {isa = PBXBuildFile; fileRef = 565029181E8FDF5600615A2C /* RxGRDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -307,6 +309,7 @@
 		5617825C1F6566EA00CEAA55 /* PrimaryKeyDiffScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryKeyDiffScanner.swift; sourceTree = "<group>"; };
 		562755D71E962BFD0035B653 /* RxGRDBmacOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxGRDBmacOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		562756571E963C1B0035B653 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		564E73AD203C99A7000C443C /* PThreadMutex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PThreadMutex.swift; sourceTree = "<group>"; };
 		565029151E8FDF5600615A2C /* RxGRDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxGRDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		565029181E8FDF5600615A2C /* RxGRDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RxGRDB.h; sourceTree = "<group>"; };
 		565029191E8FDF5600615A2C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -510,6 +513,7 @@
 		56DBA56A1F0BF20500C90A18 /* Lib */ = {
 			isa = PBXGroup;
 			children = (
+				564E73AD203C99A7000C443C /* PThreadMutex.swift */,
 				562756571E963C1B0035B653 /* Result.swift */,
 			);
 			name = Lib;
@@ -925,6 +929,7 @@
 				569E8512200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */,
 				565934191F0E157800707571 /* DatabaseRegionChangeTokensObservable.swift in Sources */,
 				562756591E963C1B0035B653 /* Result.swift in Sources */,
+				564E73AF203C99A7000C443C /* PThreadMutex.swift in Sources */,
 				56DBA5681F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5431F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
 				569E8515200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,
@@ -957,6 +962,7 @@
 				569E8511200A695A0028D1EC /* DatabaseRegionDatabaseObservable.swift in Sources */,
 				56DBA5671F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5421F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
+				564E73AE203C99A7000C443C /* PThreadMutex.swift in Sources */,
 				565933EE1F0D72A400707571 /* ChangeToken.swift in Sources */,
 				565029B31E8FE12C00615A2C /* TypedRequest+Rx.swift in Sources */,
 				569E8514200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,

--- a/RxGRDB/DatabaseRegionChangeTokensObservable.swift
+++ b/RxGRDB/DatabaseRegionChangeTokensObservable.swift
@@ -88,34 +88,3 @@ final class DatabaseRegionChangeTokensObservable : ObservableType {
         }
     }
 }
-
-final public class PThreadMutex {
-    private var mutex = pthread_mutex_t()
-    
-    public init() {
-        let result = pthread_mutex_init(&mutex, nil)
-        precondition(result == 0, "Failed to create pthread mutex")
-    }
-    
-    deinit {
-        let result = pthread_mutex_destroy(&mutex)
-        precondition(result == 0, "Failed to destroy mutex")
-    }
-    
-    fileprivate func lock() {
-        let result = pthread_mutex_lock(&mutex)
-        precondition(result == 0, "Failed to lock mutex")
-    }
-    
-    fileprivate func unlock() {
-        let result = pthread_mutex_unlock(&mutex)
-        precondition(result == 0, "Failed to unlock mutex")
-    }
-    
-    public func lock<T>(block: () throws -> T) rethrows -> T {
-        lock()
-        defer { unlock() }
-        let value = try block()
-        return value
-    }
-}

--- a/RxGRDB/PThreadMutex.swift
+++ b/RxGRDB/PThreadMutex.swift
@@ -1,0 +1,30 @@
+final public class PThreadMutex {
+    private var mutex = pthread_mutex_t()
+    
+    public init() {
+        let result = pthread_mutex_init(&mutex, nil)
+        precondition(result == 0, "Failed to create pthread mutex")
+    }
+    
+    deinit {
+        let result = pthread_mutex_destroy(&mutex)
+        precondition(result == 0, "Failed to destroy mutex")
+    }
+    
+    fileprivate func lock() {
+        let result = pthread_mutex_lock(&mutex)
+        precondition(result == 0, "Failed to lock mutex")
+    }
+    
+    fileprivate func unlock() {
+        let result = pthread_mutex_unlock(&mutex)
+        precondition(result == 0, "Failed to unlock mutex")
+    }
+    
+    public func lock<T>(block: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        let value = try block()
+        return value
+    }
+}

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,16 @@
 - [ ] Allow one to pause values observation, and restart with fresh values
-
+- [ ] Rename "change tokens" into "fetch tokens", as a support for the "changes observable" vs. "values observables" dichotomy. After this change, changes observables are observables that have "changes" in their names, and values observables are observables that have "fetch" in their name:
+    
+    ```swift
+    // A changes observable
+    request.rx.changes(in:...)...
+    
+    // A changes observable
+    dbQueue.rx.changes(in:...)...
+    
+    // A values observable
+    request.rx.fetchAll(in:...)
+    
+    // A values observable
+    dbQueue.rx.fetchTokens(in:...).mapFetch(...)...
+    ```


### PR DESCRIPTION
This PR fixes a bug that would have [values observables](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#values-observables) fail to observe some database changes.

Due to my misunderstanding of schedulers, a values observable that 1. targets the main thread, and 2. is subscribed off the main thread would... immediately stop observing the database 🤦‍♂️. Things are better now 😅