### PR TITLE
Synchronous emission of the initially fetched values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+## 0.10.0
+
+### New
+
+- Unless they are provided an explicit scheduler, [values observables](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#values-observables) subscribed from the main queue are now guaranteed a synchronous emission of their initial value ([#28](https://github.com/RxSwiftCommunity/RxGRDB/pull/28)).
+
+### Documentation Diff
+
+- The [Values Observables](https://github.com/RxSwiftCommunity/RxGRDB/blob/master/README.md#values-observables) chapter now describes the scheduling of fetched values.
+
+
 ## 0.9.0
 
 Released February 25, 2018 &bull; [diff](https://github.com/RxSwiftCommunity/RxGRDB/compare/v0.8.1...v0.9.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-## 0.10.0
+## Next version
 
 ### New
 

--- a/RxGRDB.xcodeproj/project.pbxproj
+++ b/RxGRDB.xcodeproj/project.pbxproj
@@ -35,18 +35,18 @@
 		565029C41E9130F600615A2C /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565029C31E9130F600615A2C /* Support.swift */; };
 		565029C61E91318F00615A2C /* TypedRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565029C51E91318F00615A2C /* TypedRequestTests.swift */; };
 		565933EE1F0D72A400707571 /* FetchToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565933ED1F0D72A400707571 /* FetchToken.swift */; };
-		565934181F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift */; };
-		565934191F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift */; };
+		565934181F0E157800707571 /* FetchTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* FetchTokensObservable.swift */; };
+		565934191F0E157800707571 /* FetchTokensObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934171F0E157800707571 /* FetchTokensObservable.swift */; };
 		565934451F0EB6BC00707571 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */; };
 		565934461F0EB6BC00707571 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */; };
 		565934481F0F419600707571 /* FetchTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934471F0F419600707571 /* FetchTokenTests.swift */; };
 		565934491F0F419600707571 /* FetchTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565934471F0F419600707571 /* FetchTokenTests.swift */; };
 		567043E21F66A7B9000A44BA /* RowValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567043E11F66A7B9000A44BA /* RowValueTests.swift */; };
 		567043E31F66A7B9000A44BA /* RowValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567043E11F66A7B9000A44BA /* RowValueTests.swift */; };
-		569E8511200A695A0028D1EC /* DatabaseRegionChangesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* DatabaseRegionChangesObservable.swift */; };
-		569E8512200A695A0028D1EC /* DatabaseRegionChangesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* DatabaseRegionChangesObservable.swift */; };
-		569E8514200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */; };
-		569E8515200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */; };
+		569E8511200A695A0028D1EC /* ChangesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* ChangesObservable.swift */; };
+		569E8512200A695A0028D1EC /* ChangesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8510200A695A0028D1EC /* ChangesObservable.swift */; };
+		569E8514200A69D20028D1EC /* DatabaseRegionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionObserver.swift */; };
+		569E8515200A69D20028D1EC /* DatabaseRegionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569E8513200A69D20028D1EC /* DatabaseRegionObserver.swift */; };
 		56DBA52F1F0BB02200C90A18 /* MapFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA52E1F0BB02200C90A18 /* MapFetch.swift */; };
 		56DBA5301F0BB02200C90A18 /* MapFetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA52E1F0BB02200C90A18 /* MapFetch.swift */; };
 		56DBA5421F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DBA5411F0BF12B00C90A18 /* GRDB+Rx.swift */; };
@@ -323,12 +323,12 @@
 		565029C31E9130F600615A2C /* Support.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Support.swift; sourceTree = "<group>"; };
 		565029C51E91318F00615A2C /* TypedRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedRequestTests.swift; sourceTree = "<group>"; };
 		565933ED1F0D72A400707571 /* FetchToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchToken.swift; sourceTree = "<group>"; };
-		565934171F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionFetchTokensObservable.swift; sourceTree = "<group>"; };
+		565934171F0E157800707571 /* FetchTokensObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchTokensObservable.swift; sourceTree = "<group>"; };
 		565934441F0EB6BC00707571 /* DatabaseWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseWriterTests.swift; sourceTree = "<group>"; };
 		565934471F0F419600707571 /* FetchTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchTokenTests.swift; sourceTree = "<group>"; };
 		567043E11F66A7B9000A44BA /* RowValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowValueTests.swift; sourceTree = "<group>"; };
-		569E8510200A695A0028D1EC /* DatabaseRegionChangesObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionChangesObservable.swift; sourceTree = "<group>"; };
-		569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionChangeObserver.swift; sourceTree = "<group>"; };
+		569E8510200A695A0028D1EC /* ChangesObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangesObservable.swift; sourceTree = "<group>"; };
+		569E8513200A69D20028D1EC /* DatabaseRegionObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObserver.swift; sourceTree = "<group>"; };
 		56D65F031EF8F5740098466C /* RxGRDB.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = RxGRDB.podspec; sourceTree = "<group>"; };
 		56D65F261EF8F5C60098466C /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		56DBA52E1F0BB02200C90A18 /* MapFetch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapFetch.swift; sourceTree = "<group>"; };
@@ -501,11 +501,11 @@
 		56DBA5691F0BF1EF00C90A18 /* Implementations */ = {
 			isa = PBXGroup;
 			children = (
+				569E8510200A695A0028D1EC /* ChangesObservable.swift */,
+				569E8513200A69D20028D1EC /* DatabaseRegionObserver.swift */,
 				561782561F655DAC00CEAA55 /* DiffSupport.swift */,
+				565934171F0E157800707571 /* FetchTokensObservable.swift */,
 				56DBA52E1F0BB02200C90A18 /* MapFetch.swift */,
-				565934171F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift */,
-				569E8510200A695A0028D1EC /* DatabaseRegionChangesObservable.swift */,
-				569E8513200A69D20028D1EC /* DatabaseRegionChangeObserver.swift */,
 			);
 			name = Implementations;
 			sourceTree = "<group>";
@@ -926,13 +926,13 @@
 				5617825E1F6566EA00CEAA55 /* PrimaryKeyDiffScanner.swift in Sources */,
 				561782581F655DAC00CEAA55 /* DiffSupport.swift in Sources */,
 				560F92CC1E94DF830077EADF /* Request+Rx.swift in Sources */,
-				569E8512200A695A0028D1EC /* DatabaseRegionChangesObservable.swift in Sources */,
-				565934191F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift in Sources */,
+				569E8512200A695A0028D1EC /* ChangesObservable.swift in Sources */,
+				565934191F0E157800707571 /* FetchTokensObservable.swift in Sources */,
 				562756591E963C1B0035B653 /* Result.swift in Sources */,
 				564E73AF203C99A7000C443C /* PThreadMutex.swift in Sources */,
 				56DBA5681F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5431F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
-				569E8515200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,
+				569E8515200A69D20028D1EC /* DatabaseRegionObserver.swift in Sources */,
 				560F92CF1E94DF830077EADF /* TypedRequest+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -959,14 +959,14 @@
 				5617825D1F6566EA00CEAA55 /* PrimaryKeyDiffScanner.swift in Sources */,
 				561782571F655DAC00CEAA55 /* DiffSupport.swift in Sources */,
 				565029BA1E91265A00615A2C /* Request+Rx.swift in Sources */,
-				569E8511200A695A0028D1EC /* DatabaseRegionChangesObservable.swift in Sources */,
+				569E8511200A695A0028D1EC /* ChangesObservable.swift in Sources */,
 				56DBA5671F0BF1A500C90A18 /* DatabaseWriter+Rx.swift in Sources */,
 				56DBA5421F0BF12B00C90A18 /* GRDB+Rx.swift in Sources */,
 				564E73AE203C99A7000C443C /* PThreadMutex.swift in Sources */,
 				565933EE1F0D72A400707571 /* FetchToken.swift in Sources */,
 				565029B31E8FE12C00615A2C /* TypedRequest+Rx.swift in Sources */,
-				569E8514200A69D20028D1EC /* DatabaseRegionChangeObserver.swift in Sources */,
-				565934181F0E157800707571 /* DatabaseRegionFetchTokensObservable.swift in Sources */,
+				569E8514200A69D20028D1EC /* DatabaseRegionObserver.swift in Sources */,
+				565934181F0E157800707571 /* FetchTokensObservable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxGRDB/ChangesObservable.swift
+++ b/RxGRDB/ChangesObservable.swift
@@ -5,7 +5,7 @@
 #endif
 import RxSwift
 
-final class DatabaseRegionChangesObservable : ObservableType {
+final class ChangesObservable : ObservableType {
     typealias E = Database
     let writer: DatabaseWriter
     let startImmediately: Bool
@@ -31,12 +31,12 @@ final class DatabaseRegionChangesObservable : ObservableType {
         do {
             let writer = self.writer
             
-            let transactionObserver = try writer.unsafeReentrantWrite { db -> DatabaseRegionChangeObserver in
+            let transactionObserver = try writer.unsafeReentrantWrite { db -> DatabaseRegionObserver in
                 if startImmediately {
                     observer.onNext(db)
                 }
                 
-                let transactionObserver = try DatabaseRegionChangeObserver(
+                let transactionObserver = try DatabaseRegionObserver(
                     observedRegion: observedRegion(db),
                     onChange: { observer.onNext(db) })
                 db.add(transactionObserver: transactionObserver)
@@ -54,4 +54,4 @@ final class DatabaseRegionChangesObservable : ObservableType {
         }
     }
 }
- 
+

--- a/RxGRDB/DatabaseRegionObserver.swift
+++ b/RxGRDB/DatabaseRegionObserver.swift
@@ -4,7 +4,7 @@
     import GRDB
 #endif
 
-final class DatabaseRegionChangeObserver : TransactionObserver {
+final class DatabaseRegionObserver : TransactionObserver {
     var changed: Bool = false
     let observedRegion: DatabaseRegion
     let change: () -> Void
@@ -44,5 +44,3 @@ final class DatabaseRegionChangeObserver : TransactionObserver {
     func databaseWillChange(with event: DatabasePreUpdateEvent) { }
     #endif
 }
-
-

--- a/RxGRDB/DatabaseWriter+Rx.swift
+++ b/RxGRDB/DatabaseWriter+Rx.swift
@@ -54,7 +54,7 @@ extension Reactive where Base: DatabaseWriter {
         startImmediately: Bool = true)
         -> Observable<Database>
     {
-        return DatabaseRegionChangesObservable(
+        return ChangesObservable(
             writer: base,
             startImmediately: startImmediately,
             observedRegion: { db in try requests.map { try $0.fetchedRegion(db) }.union() })
@@ -93,13 +93,19 @@ extension Reactive where Base: DatabaseWriter {
     public func fetchTokens(
         in requests: [Request],
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance)
+        scheduler: ImmediateSchedulerType? = nil)
         -> Observable<FetchToken>
     {
-        return DatabaseRegionFetchTokensObservable(
+        let fetchTokenScheduler: FetchTokenScheduler
+        if let scheduler = scheduler {
+            fetchTokenScheduler = .scheduler(scheduler)
+        } else {
+            fetchTokenScheduler = .mainQueue
+        }
+        return FetchTokensObservable(
             writer: base,
             startImmediately: startImmediately,
-            scheduler: scheduler,
+            scheduler: fetchTokenScheduler,
             observedRegion: { db in try requests.map { try $0.fetchedRegion(db) }.union() })
             .asObservable()
     }
@@ -109,15 +115,10 @@ extension Reactive where Base: DatabaseWriter {
     public func changeTokens(
         in requests: [Request],
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance)
+        scheduler: ImmediateSchedulerType? = nil)
         -> Observable<FetchToken>
     {
-        return DatabaseRegionFetchTokensObservable(
-            writer: base,
-            startImmediately: startImmediately,
-            scheduler: scheduler,
-            observedRegion: { db in try requests.map { try $0.fetchedRegion(db) }.union() })
-            .asObservable()
+        return fetchTokens(in: requests, startImmediately: startImmediately, scheduler: scheduler)
     }
 }
 

--- a/RxGRDB/FetchToken.swift
+++ b/RxGRDB/FetchToken.swift
@@ -30,11 +30,10 @@ public struct FetchToken {
         case subscription
         
         /// Emitted from the database writer dispatch queue.
-        case change(DatabaseWriter, Database)
+        case change(DatabaseWriter, FetchTokenScheduler)
     }
     
     var kind: Kind
-    var scheduler: FetchTokenScheduler
 }
 
 /// Not public: how fetched values should be scheduled

--- a/RxGRDB/FetchToken.swift
+++ b/RxGRDB/FetchToken.swift
@@ -34,7 +34,47 @@ public struct FetchToken {
     }
     
     var kind: Kind
-    var scheduler: ImmediateSchedulerType
+    var scheduler: FetchTokenScheduler
+}
+
+/// Not public: how fetched values should be scheduled
+enum FetchTokenScheduler {
+    /// Schedules with an RxSwift scheduler
+    case scheduler(ImmediateSchedulerType)
+    
+    /// Schedules on the main queue. This specific scheduling technique
+    /// guarantees that the initially fetched values are synchronous delivered
+    /// on the main queue. That last guarantee can't be fulfilled by
+    /// MainScheduler.instance.
+    case mainQueue
+    
+    func schedule(action: @escaping () -> Void) {
+        switch self {
+        case .scheduler(let scheduler):
+            _ = scheduler.schedule(()) { _ in
+                action()
+                return Disposables.create()
+            }
+        case .mainQueue:
+            if DispatchQueue.isMain {
+                action()
+            } else {
+                DispatchQueue.main.async(execute: action)
+            }
+        }
+    }
+}
+
+extension DispatchQueue {
+    private static var token: DispatchSpecificKey<()> = {
+        let key = DispatchSpecificKey<()>()
+        DispatchQueue.main.setSpecific(key: key, value: ())
+        return key
+    }()
+    
+    static var isMain: Bool {
+        return DispatchQueue.getSpecific(key: token) != nil
+    }
 }
 
 extension ObservableType where E == FetchToken {

--- a/RxGRDB/FetchTokensObservable.swift
+++ b/RxGRDB/FetchTokensObservable.swift
@@ -60,18 +60,18 @@ final class FetchTokensObservable : ObservableType {
                     
                     transactionObserver = try writer.unsafeReentrantWrite { db -> DatabaseRegionObserver in
                         if startImmediately {
-                            observer.onNext(FetchToken(kind: .databaseSubscription(db), scheduler: scheduler))
+                            observer.onNext(FetchToken(kind: .databaseSubscription(db)))
                         }
                         
                         let transactionObserver = try DatabaseRegionObserver(
                             observedRegion: observedRegion(db),
-                            onChange: { observer.onNext(FetchToken(kind: .change(writer, db), scheduler: scheduler)) })
+                            onChange: { observer.onNext(FetchToken(kind: .change(writer, scheduler))) })
                         db.add(transactionObserver: transactionObserver)
                         return transactionObserver
                     }
                     
                     if startImmediately {
-                        observer.onNext(FetchToken(kind: .subscription, scheduler: scheduler))
+                        observer.onNext(FetchToken(kind: .subscription))
                     }
                 }
                 

--- a/RxGRDB/MapFetch.swift
+++ b/RxGRDB/MapFetch.swift
@@ -61,7 +61,7 @@ class MapFetch<ResultType> : ObservableType {
                     // Several `change` token may have already been received.
                     observer.onResult(initialResult!)
                     
-                case .change(let writer, _):
+                case .change(let writer, let scheduler):
                     // Current dispatch queue: the database writer dispatch queue
                     // This token is emitted after a transaction has been committed.
                     //
@@ -97,7 +97,7 @@ class MapFetch<ResultType> : ObservableType {
                         
                         guard let result = result else { return }
                         
-                        fetchToken.scheduler.schedule {
+                        scheduler.schedule {
                             if !subscription.isDisposed {
                                 observer.onResult(result)
                             }

--- a/RxGRDB/MapFetch.swift
+++ b/RxGRDB/MapFetch.swift
@@ -97,11 +97,10 @@ class MapFetch<ResultType> : ObservableType {
                         
                         guard let result = result else { return }
                         
-                        _ = fetchToken.scheduler.schedule(result) { result in
+                        fetchToken.scheduler.schedule {
                             if !subscription.isDisposed {
                                 observer.onResult(result)
                             }
-                            return Disposables.create()
                         }
                     }
                 }

--- a/RxGRDB/Request+Rx.swift
+++ b/RxGRDB/Request+Rx.swift
@@ -99,7 +99,7 @@ extension Reactive where Base: Request {
     public func fetchCount(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance)
+        scheduler: ImmediateSchedulerType? = nil)
         -> Observable<Int>
     {
         let request = base

--- a/RxGRDB/TypedRequest+Rx.swift
+++ b/RxGRDB/TypedRequest+Rx.swift
@@ -26,7 +26,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: RowConvertible {
     public func fetchAll(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<[Base.RowDecoder]>
     {
@@ -60,7 +60,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: RowConvertible {
     public func fetchOne(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<Base.RowDecoder?>
     {
@@ -98,7 +98,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: Row {
     public func fetchAll(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<[Row]>
     {
@@ -131,7 +131,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: Row {
     public func fetchOne(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<Row?>
     {
@@ -169,7 +169,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: DatabaseValueConve
     public func fetchAll(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<[Base.RowDecoder]>
     {
@@ -203,7 +203,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: DatabaseValueConve
     public func fetchOne(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<Base.RowDecoder?>
     {
@@ -249,7 +249,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: _OptionalProtocol,
     public func fetchAll(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<[Base.RowDecoder._Wrapped?]>
     {
@@ -287,7 +287,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: DatabaseValueConve
     public func fetchAll(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<[Base.RowDecoder]>
     {
@@ -321,7 +321,7 @@ extension Reactive where Base: TypedRequest, Base.RowDecoder: DatabaseValueConve
     public func fetchOne(
         in writer: DatabaseWriter,
         startImmediately: Bool = true,
-        scheduler: ImmediateSchedulerType = MainScheduler.instance,
+        scheduler: ImmediateSchedulerType? = nil,
         distinctUntilChanged: Bool = false)
         -> Observable<Base.RowDecoder?>
     {

--- a/Tests/FetchTokenTests.swift
+++ b/Tests/FetchTokenTests.swift
@@ -74,13 +74,13 @@ extension FetchTokenTests {
 extension FetchTokenTests {
     
     // This is a regression test that fails in v0.8.0
-    func testAsynchronousSubscription() throws {
-        try Test(testAsynchronousSubscription)
+    func testSubscriptionOffMainThread() throws {
+        try Test(testSubscriptionOffMainThread)
             .run { try DatabaseQueue(path: $0) }
             .run { try DatabasePool(path: $0) }
     }
     
-    func testAsynchronousSubscription(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+    func testSubscriptionOffMainThread(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
         try writer.write { db in
             try db.create(table: "t") { t in
                 t.column("id", .integer).primaryKey()
@@ -123,3 +123,48 @@ extension FetchTokenTests {
     }
 }
 
+extension FetchTokenTests {
+    
+    // This is a regression test that fails in v0.9.0
+    func testSubscriptionFromMainThread() throws {
+        try Test(testSubscriptionFromMainThread)
+            .run { try DatabaseQueue(path: $0) }
+            .run { try DatabasePool(path: $0) }
+    }
+    
+    func testSubscriptionFromMainThread(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+        try writer.write { db in
+            try db.create(table: "t") { t in
+                t.column("id", .integer).primaryKey()
+            }
+        }
+        
+        var disposable: Disposable? {
+            willSet { disposable?.dispose() }
+            didSet { disposable?.disposed(by: disposeBag) }
+        }
+        
+        let request = SQLRequest("SELECT COUNT(*) FROM t").asRequest(of: Int.self)
+        
+        var count1: Int? = nil
+        var count2: Int? = nil
+        request.rx.fetchOne(in: writer)
+            .subscribe(onNext: {
+                XCTAssertTrue(Thread.isMainThread)
+                count1 = $0
+            })
+            .disposed(by: disposeBag)
+        try writer.write { db in
+            try db.execute("INSERT INTO t DEFAULT VALUES")
+        }
+        request.rx.fetchOne(in: writer)
+            .subscribe(onNext: {
+                XCTAssertTrue(Thread.isMainThread)
+                count2 = $0
+            })
+            .disposed(by: disposeBag)
+        
+        XCTAssertEqual(count1, 0)
+        XCTAssertEqual(count2, 1)
+    }
+}


### PR DESCRIPTION
This PR restores a very useful behavior that has been lost after the transition to RxSwift schedulers in v0.8.0, which is the guarantee, for database observables that target the main thread, of the synchronous emission of the initially fetched database values.

This feature is very important for view controllers that subscribe to database values in their viewDidLoad() method and rely on synchronous view setup:

```swift
override func viewDidLoad() {
    super.viewDidLoad()
    
    Player.all().rx
        .fetchAll(in: dbQueue)
        .subscribe(onNext: { [weak self] players in
            self?.updateView(players)
        })
        .disposed(by: disposeBag)
    
    // <- Here the view has been updated
}
```

Since v0.8.0, this useful behavior has been provided by the good old [MainScheduler.instance](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Schedulers.md#mainscheduler-serial-scheduler).

**But this is not enough.**

Applications also need, sometimes, to update the database and then take immediate action without waiting for the database change notification that will eventually come (changes notifications are always asynchronously dispatched).

For example, an app may need to insert a row in the database, update the view, and then select and scroll to the matching row in a table view.

*This use case is difficult when the delivery of updated database values is asynchronous*. It requires heavy Rx setup in order to provide specific handling of the expected database change notification, only this one, and not others (considering any background thread may also perform database changes in the mean time).

It is not only difficult, but also error-prone. It's very easy to do it in a wrong way.

Conversely, this use case can be handled in a much easier way by simply resubscribing to the database content right after the database change. Here is the suggested setup:

```swift
override func viewDidLoad() {
    super.viewDidLoad()
    trackDatabase()
    // <- Here the view has been updated (1)
}

@IBAction func doStuff(_ sender: Any?) {
    try! dbQueue.inDatabase { db in
        // update database
    }
    
    // Resubscribe to the database content
    trackDatabase()
    // <- Here the view has been updated (2)
    
    // Further process updated view
    ...
}

private func trackDatabase() {
    databaseSubscription = Player.all().rx
        .fetchAll(in: dbQueue)
        .subscribe(onNext: { [weak self] players in
            self?.updateView(players)
        })
}

// The subscription to the database
private var databaseSubscription: Disposable? {
    willSet { databaseSubscription?.dispose() }
    didSet { databaseSubscription?.disposed(by: disposeBag) }
}
```

Did you notice the two "Here the view has been updated" comments above? The first one was already guaranteed. The second one is only guaranteed by this PR.

To achieve this behavior, RxGRDB no longer defaults to MainScheduler.instance.

To understand why MainScheduler.instance is not a correct fit, let's analyse what happens in the `doStuff` method:

1. When the database is changed, MainScheduler.instance would asynchronously schedule a database change handler (the one that has been setup in viewDidLoad > trackDatabase).
2. The subsequent call to trackDatabase immediately schedules a database change handler with MainScheduler.instance. But this handler can't run synchronously because of the previously scheduled one which has not yet been executed. It is asynchronously dispatched.
3. We now have a problem: the view has not been updated after the call to trackDatabase.
4. Unsubscribing from database changes before updating the database is not a sufficient fix: there may exist other database subscriptions that would make MainScheduler.instance asynchronously schedule database change handlers anyway.

This is not a bug of MainScheduler.instance, which makes very sure that scheduled items are executed in the same order as they are scheduled. It just happens that this ordering goes against the interest of the scenario detailed above: when an app needs *synchronous* notification, it *needs* to opt out from the strict scheduler ordering.

Applications that rely on strict ordering can still provide an explicit scheduler, as below. But they lose synchronous notifications:

```swift
Player.all().rx
    .fetchAll(in: dbQueue, scheduler: MainScheduler.instance)
    .subscribe(onNext: { [weak self] players in
        self?.updateView(players)
    })
// <- Here the view may not be updated yet
```