### PR TITLE
Expose `rx` joiner on database existentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## Next Release
+
+- [#58](https://github.com/RxSwiftCommunity/RxGRDB/pull/58): Expose `rx` joiner on database existentials
+
 ## 0.16.0
 
 Released June 27, 2019 &bull; [diff](https://github.com/RxSwiftCommunity/RxGRDB/compare/v0.15.0...v0.16.0)

--- a/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
+++ b/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		565BD7C722C3F97900BB9B5A /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E1F9951F81033200793BFA /* Player.swift */; };
 		565BD7C922C3FA8B00BB9B5A /* PlayersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */; };
 		565BD7CA22C3FAA700BB9B5A /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A322C3A9BC00A6FF66 /* Players.swift */; };
+		565BD7D022C49D2100BB9B5A /* PlayersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */; };
+		565BD7D122C49D9800BB9B5A /* PlayersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */; };
+		565BD7D222C49E6600BB9B5A /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A122C3A7DC00A6FF66 /* World.swift */; };
+		565BD7D322C49EAA00BB9B5A /* Action+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515AA22C3CDAC00A6FF66 /* Action+App.swift */; };
 		567515A222C3A7DC00A6FF66 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A122C3A7DC00A6FF66 /* World.swift */; };
 		567515A422C3A9BC00A6FF66 /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A322C3A9BC00A6FF66 /* Players.swift */; };
 		567515A822C3B1F100A6FF66 /* PlayersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */; };
@@ -57,6 +61,7 @@
 		565BD7BA22C3F84A00BB9B5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		565BD7C422C3F8D600BB9B5A /* AppDatabaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDatabaseTests.swift; sourceTree = "<group>"; };
 		565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersTests.swift; sourceTree = "<group>"; };
+		565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersViewModelTests.swift; sourceTree = "<group>"; };
 		567515A122C3A7DC00A6FF66 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
 		567515A322C3A9BC00A6FF66 /* Players.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Players.swift; sourceTree = "<group>"; };
 		567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersViewModel.swift; sourceTree = "<group>"; };
@@ -102,6 +107,7 @@
 				565BD7BA22C3F84A00BB9B5A /* Info.plist */,
 				565BD7C422C3F8D600BB9B5A /* AppDatabaseTests.swift */,
 				565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */,
+				565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */,
 			);
 			path = RxGRDBDemoTests;
 			sourceTree = "<group>";
@@ -333,14 +339,20 @@
 				"${BUILT_PRODUCTS_DIR}/GRDB.swift-iOS/GRDB.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift-iOS/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/RxBlocking-iOS/RxBlocking.framework",
+				"${BUILT_PRODUCTS_DIR}/Action/Action.framework",
+				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxGRDB/RxGRDB.framework",
+				"${BUILT_PRODUCTS_DIR}/RxRelay/RxRelay.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GRDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxBlocking.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Action.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxGRDB.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRelay.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -404,10 +416,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				565BD7D122C49D9800BB9B5A /* PlayersViewModel.swift in Sources */,
 				565BD7C922C3FA8B00BB9B5A /* PlayersTests.swift in Sources */,
 				565BD7CA22C3FAA700BB9B5A /* Players.swift in Sources */,
+				565BD7D322C49EAA00BB9B5A /* Action+App.swift in Sources */,
 				565BD7C622C3F92F00BB9B5A /* AppDatabase.swift in Sources */,
+				565BD7D022C49D2100BB9B5A /* PlayersViewModelTests.swift in Sources */,
 				565BD7C722C3F97900BB9B5A /* Player.swift in Sources */,
+				565BD7D222C49E6600BB9B5A /* World.swift in Sources */,
 				565BD7C522C3F8D600BB9B5A /* AppDatabaseTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
+++ b/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
@@ -108,9 +108,9 @@
 			children = (
 				565BD7BA22C3F84A00BB9B5A /* Info.plist */,
 				565BD7C422C3F8D600BB9B5A /* AppDatabaseTests.swift */,
-				565BD7D822C5DEE800BB9B5A /* PlayerTests.swift */,
 				565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */,
 				565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */,
+				565BD7D822C5DEE800BB9B5A /* PlayerTests.swift */,
 			);
 			path = RxGRDBDemoTests;
 			sourceTree = "<group>";

--- a/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
+++ b/Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		565BD7D122C49D9800BB9B5A /* PlayersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */; };
 		565BD7D222C49E6600BB9B5A /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A122C3A7DC00A6FF66 /* World.swift */; };
 		565BD7D322C49EAA00BB9B5A /* Action+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515AA22C3CDAC00A6FF66 /* Action+App.swift */; };
+		565BD7D922C5DEE800BB9B5A /* PlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565BD7D822C5DEE800BB9B5A /* PlayerTests.swift */; };
 		567515A222C3A7DC00A6FF66 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A122C3A7DC00A6FF66 /* World.swift */; };
 		567515A422C3A9BC00A6FF66 /* Players.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A322C3A9BC00A6FF66 /* Players.swift */; };
 		567515A822C3B1F100A6FF66 /* PlayersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */; };
@@ -62,6 +63,7 @@
 		565BD7C422C3F8D600BB9B5A /* AppDatabaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDatabaseTests.swift; sourceTree = "<group>"; };
 		565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersTests.swift; sourceTree = "<group>"; };
 		565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersViewModelTests.swift; sourceTree = "<group>"; };
+		565BD7D822C5DEE800BB9B5A /* PlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerTests.swift; sourceTree = "<group>"; };
 		567515A122C3A7DC00A6FF66 /* World.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = World.swift; sourceTree = "<group>"; };
 		567515A322C3A9BC00A6FF66 /* Players.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Players.swift; sourceTree = "<group>"; };
 		567515A722C3B1F100A6FF66 /* PlayersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayersViewModel.swift; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 			children = (
 				565BD7BA22C3F84A00BB9B5A /* Info.plist */,
 				565BD7C422C3F8D600BB9B5A /* AppDatabaseTests.swift */,
+				565BD7D822C5DEE800BB9B5A /* PlayerTests.swift */,
 				565BD7C822C3FA8B00BB9B5A /* PlayersTests.swift */,
 				565BD7CF22C49D2100BB9B5A /* PlayersViewModelTests.swift */,
 			);
@@ -416,6 +419,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				565BD7D922C5DEE800BB9B5A /* PlayerTests.swift in Sources */,
 				565BD7D122C49D9800BB9B5A /* PlayersViewModel.swift in Sources */,
 				565BD7C922C3FA8B00BB9B5A /* PlayersTests.swift in Sources */,
 				565BD7CA22C3FAA700BB9B5A /* Players.swift in Sources */,

--- a/Documentation/RxGRDBDemo/RxGRDBDemo/Models/Player.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemo/Models/Player.swift
@@ -38,7 +38,7 @@ extension DerivableRequest where RowDecoder == Player {
     }
     
     func orderByName() -> Self {
-        return order(Player.Columns.name)
+        return order(Player.Columns.name, Player.Columns.score.desc)
     }
 }
 

--- a/Documentation/RxGRDBDemo/RxGRDBDemo/Models/Players.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemo/Models/Players.swift
@@ -20,21 +20,17 @@ struct Players {
     }
     
     func deleteAll() -> Completable {
-        // Erase the database writer type in an AnyDatabaseWriter, so that we
-        // accept a DatabasePool in the app, a DatabaseQueue in tests, and also
-        // have access to the RxGRDB APIs with the `rx` joiner defined on the
-        // ReactiveCompatible protocol.
-        return AnyDatabaseWriter(database).rx.write(updates: _deleteAll)
+        return database.rx.write(updates: _deleteAll)
     }
     
     func deleteOne(_ player: Player) -> Completable {
-        return AnyDatabaseWriter(database).rx.write(updates: { db in
+        return database.rx.write(updates: { db in
             try self._deleteOne(db, player: player)
         })
     }
     
     func refresh() -> Completable {
-        return AnyDatabaseWriter(database).rx.write(updates: _refresh)
+        return database.rx.write(updates: _refresh)
     }
     
     func stressTest() -> Completable {

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/AppDatabaseTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/AppDatabaseTests.swift
@@ -7,28 +7,7 @@ class AppDatabaseTests: XCTestCase {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         try dbQueue.read { db in
-            try XCTAssert(db.tableExists(Player.databaseTableName))
-        }
-    }
-    
-    func testCanInsertPlayer() throws {
-        let dbQueue = DatabaseQueue()
-        try AppDatabase().setup(dbQueue)
-        try dbQueue.write { db in
-            var player = Player(id: nil, name: "Arthur", score: 100)
-            try player.insert(db)
-            XCTAssertNotNil(player.id)
-        }
-    }
-    
-    func testPlayerRoundtrip() throws {
-        let dbQueue = DatabaseQueue()
-        try AppDatabase().setup(dbQueue)
-        try dbQueue.write { db in
-            var insertedPlayer = Player(id: 1, name: "Arthur", score: 100)
-            try insertedPlayer.insert(db)
-            let fetchedPlayer = try Player.fetchOne(db, key: 1)
-            XCTAssertEqual(insertedPlayer, fetchedPlayer)
+            try XCTAssert(db.tableExists("player"))
         }
     }
 }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/AppDatabaseTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/AppDatabaseTests.swift
@@ -8,6 +8,9 @@ class AppDatabaseTests: XCTestCase {
         try AppDatabase().setup(dbQueue)
         try dbQueue.read { db in
             try XCTAssert(db.tableExists("player"))
+            let columns = try db.columns(in: "player")
+            let columnNames = Set(columns.map { $0.name })
+            XCTAssertEqual(columnNames, ["id", "name", "score"])
         }
     }
 }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayerTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayerTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import GRDB
+
+class PlayerTests: XCTestCase {
+    
+    func testInsert() throws {
+        let dbQueue = DatabaseQueue()
+        try AppDatabase().setup(dbQueue)
+        try dbQueue.write { db in
+            var player = Player(id: nil, name: "Arthur", score: 100)
+            try player.insert(db)
+            XCTAssertNotNil(player.id)
+        }
+    }
+    
+    func testRoundtrip() throws {
+        let dbQueue = DatabaseQueue()
+        try AppDatabase().setup(dbQueue)
+        try dbQueue.write { db in
+            var insertedPlayer = Player(id: 1, name: "Arthur", score: 100)
+            try insertedPlayer.insert(db)
+            let fetchedPlayer = try Player.fetchOne(db, key: 1)
+            XCTAssertEqual(insertedPlayer, fetchedPlayer)
+        }
+    }
+    
+    func testOrderByScore() throws {
+        let dbQueue = DatabaseQueue()
+        try AppDatabase().setup(dbQueue)
+        
+        var player1 = Player(id: 1, name: "Arthur", score: 100)
+        var player2 = Player(id: 2, name: "Barbara", score: 200)
+        var player3 = Player(id: 3, name: "Craig", score: 150)
+        var player4 = Player(id: 4, name: "David", score: 150)
+        try dbQueue.write { db in
+            try player1.insert(db)
+            try player2.insert(db)
+            try player3.insert(db)
+            try player4.insert(db)
+        }
+        
+        try XCTAssertEqual(
+            dbQueue.read(Player.all().orderByScore().fetchAll),
+            [player2, player3, player4, player1])
+        
+        try dbQueue.write { db in
+            _ = try player1.updateChanges(db) { $0.score = 300 }
+        }
+        
+        try XCTAssertEqual(
+            dbQueue.read(Player.all().orderByScore().fetchAll),
+            [player1, player2, player3, player4])
+    }
+    
+    func testOrderByName() throws {
+        let dbQueue = DatabaseQueue()
+        try AppDatabase().setup(dbQueue)
+        
+        var player1 = Player(id: 1, name: "Arthur", score: 100)
+        var player2 = Player(id: 2, name: "Barbara", score: 200)
+        var player3 = Player(id: 3, name: "Craig", score: 150)
+        var player4 = Player(id: 4, name: "David", score: 150)
+        try dbQueue.write { db in
+            try player1.insert(db)
+            try player2.insert(db)
+            try player3.insert(db)
+            try player4.insert(db)
+        }
+        
+        try XCTAssertEqual(
+            dbQueue.read(Player.all().orderByName().fetchAll),
+            [player1, player2, player3, player4])
+        
+        try dbQueue.write { db in
+            _ = try player1.updateChanges(db) { $0.name = "Craig" }
+        }
+        
+        try XCTAssertEqual(
+            dbQueue.read(Player.all().orderByName().fetchAll),
+            [player2, player3, player1, player4])
+    }
+}

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayerTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayerTests.swift
@@ -27,7 +27,6 @@ class PlayerTests: XCTestCase {
     func testOrderByScore() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
-        
         var player1 = Player(id: 1, name: "Arthur", score: 100)
         var player2 = Player(id: 2, name: "Barbara", score: 200)
         var player3 = Player(id: 3, name: "Craig", score: 150)
@@ -39,8 +38,10 @@ class PlayerTests: XCTestCase {
             try player4.insert(db)
         }
         
+        let request = Player.all().orderByScore()
+        
         try XCTAssertEqual(
-            dbQueue.read(Player.all().orderByScore().fetchAll),
+            dbQueue.read(request.fetchAll),
             [player2, player3, player4, player1])
         
         try dbQueue.write { db in
@@ -48,14 +49,13 @@ class PlayerTests: XCTestCase {
         }
         
         try XCTAssertEqual(
-            dbQueue.read(Player.all().orderByScore().fetchAll),
+            dbQueue.read(request.fetchAll),
             [player1, player2, player3, player4])
     }
     
     func testOrderByName() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
-        
         var player1 = Player(id: 1, name: "Arthur", score: 100)
         var player2 = Player(id: 2, name: "Barbara", score: 200)
         var player3 = Player(id: 3, name: "Craig", score: 150)
@@ -67,8 +67,10 @@ class PlayerTests: XCTestCase {
             try player4.insert(db)
         }
         
+        let request = Player.all().orderByName()
+        
         try XCTAssertEqual(
-            dbQueue.read(Player.all().orderByName().fetchAll),
+            dbQueue.read(request.fetchAll),
             [player1, player2, player3, player4])
         
         try dbQueue.write { db in
@@ -76,7 +78,7 @@ class PlayerTests: XCTestCase {
         }
         
         try XCTAssertEqual(
-            dbQueue.read(Player.all().orderByName().fetchAll),
+            dbQueue.read(request.fetchAll),
             [player2, player3, player1, player4])
     }
 }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class PlayersTests: XCTestCase {
     
-    func testPlayersPopulateIfEmptyFromEmptyDatabase() throws {
+    func testPopulateIfEmptyFromEmptyDatabase() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
@@ -15,7 +15,7 @@ class PlayersTests: XCTestCase {
         try XCTAssertGreaterThan(dbQueue.read(Player.fetchCount), 0)
     }
     
-    func testPlayersPopulateIfEmptyFromNonEmptyDatabase() throws {
+    func testPopulateIfEmptyFromNonEmptyDatabase() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
@@ -29,7 +29,7 @@ class PlayersTests: XCTestCase {
         try XCTAssertEqual(dbQueue.read(Player.fetchAll), [player])
     }
     
-    func testPlayersDeleteAll() throws {
+    func testDeleteAll() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
@@ -39,11 +39,11 @@ class PlayersTests: XCTestCase {
             try player.insert(db)
         }
         
-        try XCTAssert(players.deleteAll().toBlocking(timeout: 1).toArray().isEmpty)
+        try XCTAssert(players.deleteAll().toBlocking().toArray().isEmpty)
         try XCTAssertEqual(dbQueue.read(Player.fetchCount), 0)
     }
     
-    func testPlayersDeleteOne() throws {
+    func testDeleteOne() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
@@ -55,21 +55,21 @@ class PlayersTests: XCTestCase {
             try player2.insert(db)
         }
         
-        try XCTAssert(players.deleteOne(player1).toBlocking(timeout: 1).toArray().isEmpty)
+        try XCTAssert(players.deleteOne(player1).toBlocking().toArray().isEmpty)
         try XCTAssertEqual(dbQueue.read(Player.fetchAll), [player2])
     }
     
-    func testPlayersRefreshPopulatesEmptyDatabase() throws {
+    func testRefreshPopulatesEmptyDatabase() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
         
         try XCTAssertEqual(dbQueue.read(Player.fetchCount), 0)
-        try XCTAssert(players.refresh().toBlocking(timeout: 1).toArray().isEmpty)
+        try XCTAssert(players.refresh().toBlocking().toArray().isEmpty)
         try XCTAssertGreaterThan(dbQueue.read(Player.fetchCount), 0)
     }
     
-    func testPlayersObserveAll() throws {
+    func testObserveAll() throws {
         let dbQueue = DatabaseQueue()
         try AppDatabase().setup(dbQueue)
         let players = Players(database: dbQueue)
@@ -101,7 +101,7 @@ class PlayersTests: XCTestCase {
         try XCTAssertEqual(
             testSubject
                 .take(expectedElements.count)
-                .toBlocking(timeout: 1)
+                .toBlocking()
                 .toArray(),
             expectedElements)
     }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
@@ -1,3 +1,4 @@
+import Action
 import GRDB
 import RxBlocking
 import RxSwift
@@ -27,5 +28,13 @@ class PlayersViewModelTests: XCTestCase {
         let players = try viewModel.players.take(1).toBlocking(timeout: 1).single()
         XCTAssertEqual(orderingButtonTitle, "Score ⬇︎")
         XCTAssert(!players.isEmpty)
+    }
+    
+    func testToggleOrdering() throws {
+        try Current.players().populateIfEmpty()
+        let viewModel = PlayersViewModel()
+        _ = viewModel.toggleOrdering.execute().toBlocking(timeout: 1).materialize()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
+        XCTAssertEqual(orderingButtonTitle, "Name ⬆︎")
     }
 }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class PlayersViewModelTests: XCTestCase {
     override func setUp() {
-        // PlayerViewModel feeds from Current World.
+        // PlayerViewModel needs a Current World.
         // Setup one with an in-memory databaase, for fast database access.
         let dbQueue = DatabaseQueue()
         try! AppDatabase().setup(dbQueue)
@@ -15,8 +15,8 @@ class PlayersViewModelTests: XCTestCase {
     
     func testInitialStateFromEmptyDatabase() throws {
         let viewModel = PlayersViewModel()
-        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
-        let players = try viewModel.players.take(1).toBlocking(timeout: 1).single()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking().single()
+        let players = try viewModel.players.take(1).toBlocking().single()
         XCTAssertNil(orderingButtonTitle)
         XCTAssert(players.isEmpty)
     }
@@ -24,8 +24,8 @@ class PlayersViewModelTests: XCTestCase {
     func testInitialStateFromNonEmptyDatabase() throws {
         try Current.players().populateIfEmpty()
         let viewModel = PlayersViewModel()
-        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
-        let players = try viewModel.players.take(1).toBlocking(timeout: 1).single()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking().single()
+        let players = try viewModel.players.take(1).toBlocking().single()
         XCTAssertEqual(orderingButtonTitle, "Score ⬇︎")
         XCTAssert(!players.isEmpty)
     }
@@ -33,8 +33,8 @@ class PlayersViewModelTests: XCTestCase {
     func testToggleOrdering() throws {
         try Current.players().populateIfEmpty()
         let viewModel = PlayersViewModel()
-        _ = viewModel.toggleOrdering.execute().toBlocking(timeout: 1).materialize()
-        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
+        _ = viewModel.toggleOrdering.execute().toBlocking().materialize()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking().single()
         XCTAssertEqual(orderingButtonTitle, "Name ⬆︎")
     }
 }

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
@@ -1,0 +1,29 @@
+import GRDB
+import RxBlocking
+import RxSwift
+import XCTest
+
+class PlayersViewModelTests: XCTestCase {
+    override func setUp() {
+        let dbQueue = DatabaseQueue()
+        try! AppDatabase().setup(dbQueue)
+        Current = World(database: { dbQueue })
+    }
+    
+    func testInitialStateFromEmptyDatabase() throws {
+        let viewModel = PlayersViewModel()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
+        let players = try viewModel.players.take(1).toBlocking(timeout: 1).single()
+        XCTAssertNil(orderingButtonTitle)
+        XCTAssert(players.isEmpty)
+    }
+    
+    func testInitialStateFromNonEmptyDatabase() throws {
+        try Current.players().populateIfEmpty()
+        let viewModel = PlayersViewModel()
+        let orderingButtonTitle = try viewModel.orderingButtonTitle.take(1).toBlocking(timeout: 1).single()
+        let players = try viewModel.players.take(1).toBlocking(timeout: 1).single()
+        XCTAssertEqual(orderingButtonTitle, "Score ⬇︎")
+        XCTAssert(!players.isEmpty)
+    }
+}

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class PlayersViewModelTests: XCTestCase {
     override func setUp() {
         // PlayerViewModel needs a Current World.
-        // Setup one with an in-memory databaase, for fast database access.
+        // Setup one with an in-memory database, for fast access.
         let dbQueue = DatabaseQueue()
         try! AppDatabase().setup(dbQueue)
         Current = World(database: { dbQueue })

--- a/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
+++ b/Documentation/RxGRDBDemo/RxGRDBDemoTests/PlayersViewModelTests.swift
@@ -5,6 +5,8 @@ import XCTest
 
 class PlayersViewModelTests: XCTestCase {
     override func setUp() {
+        // PlayerViewModel feeds from Current World.
+        // Setup one with an in-memory databaase, for fast database access.
         let dbQueue = DatabaseQueue()
         try! AppDatabase().setup(dbQueue)
         Current = World(database: { dbQueue })

--- a/Podfile
+++ b/Podfile
@@ -49,6 +49,7 @@ end
 target 'RxGRDBDemoTests' do
   project 'Documentation/RxGRDBDemo/RxGRDBDemo.xcodeproj'
   platform :ios, '9.0'
+  pod 'Action'
   pod 'RxGRDB', :path => '.'
   pod 'RxBlocking'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,10 +15,10 @@ PODS:
     - Differentiator (~> 4.0)
     - RxCocoa (~> 5.0)
     - RxSwift (~> 5.0)
-  - RxGRDB (0.15.0):
-    - RxGRDB/default (= 0.15.0)
+  - RxGRDB (0.16.0):
+    - RxGRDB/default (= 0.16.0)
     - RxSwift (~> 5.0)
-  - RxGRDB/default (0.15.0):
+  - RxGRDB/default (0.16.0):
     - GRDB.swift (~> 4.1)
     - RxSwift (~> 5.0)
   - RxRelay (5.0.0):
@@ -55,10 +55,10 @@ SPEC CHECKSUMS:
   RxBlocking: c67185d26498ea3cbe3e121917c3c16739e43123
   RxCocoa: fcf32050ac00d801f34a7f71d5e8e7f23026dcd8
   RxDataSources: efee07fa4de48477eca0a4611e6d11e2da9c1114
-  RxGRDB: c5062e17fb1db5fc16b71f493e4877b43c6430d6
+  RxGRDB: 974382f5fe057e73f2cb5e273543a8806a408b1c
   RxRelay: 4f7409406a51a55cd88483f21ed898c234d60f18
   RxSwift: 8b0671caa829a763bbce7271095859121cbd895f
 
-PODFILE CHECKSUM: 600af870ea283792eaeedde02def12b3523ba22c
+PODFILE CHECKSUM: a415d18c985ec5b37da0ee23462f2cfd56a19b1a
 
 COCOAPODS: 1.7.2

--- a/RxGRDB/DatabaseReader+Rx.swift
+++ b/RxGRDB/DatabaseReader+Rx.swift
@@ -1,10 +1,19 @@
 import GRDB
 import RxSwift
 
-extension AnyDatabaseReader: ReactiveCompatible { }
-extension DatabasePool: ReactiveCompatible { }
-extension DatabaseQueue: ReactiveCompatible { }
-extension DatabaseSnapshot: ReactiveCompatible { }
+/// We want the `rx` joiner on DatabaseReader.
+/// Normally we'd use ReactiveCompatible. But ReactiveCompatible is unable to
+/// define `rx` on existentials as well:
+///
+///     let reader: DatabaseReader
+///     reader.rx...
+///
+/// :nodoc:
+extension DatabaseReader {
+    public var rx: Reactive<AnyDatabaseReader> {
+        return Reactive(AnyDatabaseReader(self))
+    }
+}
 
 extension Reactive where Base: DatabaseReader {
     /// Returns a Single that asynchronously emits the fetched value.
@@ -38,5 +47,12 @@ extension Reactive where Base: DatabaseReader {
                 return Disposables.create { }
             }
             .observeOn(scheduler)
+    }
+}
+
+/// :nodoc:
+extension DatabaseReader where Self: ReactiveCompatible {
+    public var rx: Reactive<Self> {
+        return Reactive(self)
     }
 }

--- a/RxGRDB/DatabaseWriter+Rx.swift
+++ b/RxGRDB/DatabaseWriter+Rx.swift
@@ -1,7 +1,19 @@
 import GRDB
 import RxSwift
 
-extension AnyDatabaseWriter: ReactiveCompatible { }
+/// We want the `rx` joiner on DatabaseWriter.
+/// Normally we'd use ReactiveCompatible. But ReactiveCompatible is unable to
+/// define `rx` on existentials as well:
+///
+///     let writer: DatabaseWriter
+///     writer.rx...
+///
+/// :nodoc:
+extension DatabaseWriter {
+    public var rx: Reactive<AnyDatabaseWriter> {
+        return Reactive(AnyDatabaseWriter(self))
+    }
+}
 
 extension Reactive where Base: DatabaseWriter {
     /// Returns an Observable that asynchronously writes into the database.

--- a/Tests/DatabaseReaderReadTests.swift
+++ b/Tests/DatabaseReaderReadTests.swift
@@ -18,132 +18,149 @@ private struct Player: Codable, FetchableRecord, PersistableRecord {
     }
 }
 
-class DatabaseReaderReadTests : XCTestCase { }
-
-extension DatabaseReaderReadTests {
+class DatabaseReaderReadTests : XCTestCase {
+    func testRxJoiner() {
+        // Make sure `rx` joiner is available in various contexts
+        func f1(_ reader: DatabasePool) {
+            _ = reader.rx.read(value: { db in })
+        }
+        func f2(_ reader: DatabaseQueue) {
+            _ = reader.rx.read(value: { db in })
+        }
+        func f3(_ reader: DatabaseSnapshot) {
+            _ = reader.rx.read(value: { db in })
+        }
+        func f4<Reader: DatabaseReader>(_ reader: Reader) {
+            _ = reader.rx.read(value: { db in })
+        }
+        func f5(_ reader: DatabaseReader) {
+            _ = reader.rx.read(value: { db in })
+        }
+    }
+    
     func testRxRead() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write { db in
                 try Player.createTable(db)
                 try Player(id: 1, name: "Arthur", score: 1000).insert(db)
             }
             return writer
         }
-        try Test(testRxRead).run { try setup(DatabaseQueue()) }
-        try Test(testRxRead).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxRead).runAtPath { try setup(DatabasePool(path: $0)) }
-        try Test(testRxRead).runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
+        
+        func test(reader: DatabaseReader, disposeBag: DisposeBag) throws {
+            let single = reader.rx.read { db in try Player.fetchCount(db) }
+            let count = try single.toBlocking(timeout: 1).single()
+            XCTAssertEqual(count, 1)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
     }
     
-    func testRxRead<Reader: DatabaseReader & ReactiveCompatible>(reader: Reader, disposeBag: DisposeBag) throws {
-        let single = reader.rx.read { db in try Player.fetchCount(db) }
-        let count = try single.toBlocking(timeout: 1).single()
-        XCTAssertEqual(count, 1)
-    }
-}
-
-extension DatabaseReaderReadTests {
     func testRxReadScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
-            func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+            func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
                 try writer.write { db in
                     try Player.createTable(db)
                     try Player(id: 1, name: "Arthur", score: 1000).insert(db)
                 }
                 return writer
             }
-            try Test(testRxReadScheduler).run { try setup(DatabaseQueue()) }
-            try Test(testRxReadScheduler).runAtPath { try setup(DatabaseQueue(path: $0)) }
-            try Test(testRxReadScheduler).runAtPath { try setup(DatabasePool(path: $0)) }
-            try Test(testRxReadScheduler).runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
+            
+            func test(reader: DatabaseReader, disposeBag: DisposeBag) throws {
+                do {
+                    let single = reader.rx
+                        .read { db in try Player.fetchCount(db) }
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(.main))
+                        })
+                    _ = try single.toBlocking(timeout: 1).toArray()
+                }
+                do {
+                    let queue = DispatchQueue(label: "test")
+                    let single = reader.rx
+                        .read(
+                            observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
+                            value: { db in try Player.fetchCount(db) })
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(queue))
+                        })
+                    _ = try single.toBlocking(timeout: 1).toArray()
+                }
+            }
+            
+            try Test(test)
+                .run { try setup(DatabaseQueue()) }
+                .runAtPath { try setup(DatabaseQueue(path: $0)) }
+                .runAtPath { try setup(DatabasePool(path: $0)) }
+                .runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
         }
     }
     
-    @available(OSX 10.12, iOS 10.0, watchOS 3.0, *)
-    func testRxReadScheduler<Reader: DatabaseReader & ReactiveCompatible>(reader: Reader, disposeBag: DisposeBag) throws {
-        do {
-            let single = reader.rx
-                .read { db in try Player.fetchCount(db) }
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(.main))
-                })
-            _ = try single.toBlocking(timeout: 1).toArray()
-        }
-        do {
-            let queue = DispatchQueue(label: "test")
-            let single = reader.rx
-                .read(
-                    observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
-                    value: { db in try Player.fetchCount(db) })
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                })
-            _ = try single.toBlocking(timeout: 1).toArray()
-        }
-    }
-}
-
-extension DatabaseReaderReadTests {
     func testRxReadIsAsynchronous() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write { db in
                 try Player.createTable(db)
                 try Player(id: 1, name: "Arthur", score: 1000).insert(db)
             }
             return writer
         }
-        try Test(testRxReadIsAsynchronous).run { try setup(DatabaseQueue()) }
-        try Test(testRxReadIsAsynchronous).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxReadIsAsynchronous).runAtPath { try setup(DatabasePool(path: $0)) }
-        try Test(testRxReadIsAsynchronous).runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
-    }
-    
-    func testRxReadIsAsynchronous<Reader: DatabaseReader & ReactiveCompatible>(reader: Reader, disposeBag: DisposeBag) throws {
-        let semaphore = DispatchSemaphore(value: 0)
-        let single = reader.rx.read { db -> Int in
-            // Make sure this block executes asynchronously
-            semaphore.wait()
-            return try Player.fetchCount(db)
-        }
         
-        let count = try single
-            .asObservable()
-            .do(onSubscribed: {
-                semaphore.signal()
-            })
-            .toBlocking(timeout: 1)
-            .single()
-        XCTAssertEqual(count, 1)
-    }
-}
-
-extension DatabaseReaderReadTests {
-    func testRxReadIsReadonly() throws {
-        try Test(testRxReadIsReadonly).run { DatabaseQueue() }
-        try Test(testRxReadIsReadonly).runAtPath { try DatabaseQueue(path: $0) }
-        try Test(testRxReadIsReadonly).runAtPath { try DatabasePool(path: $0) }
-        try Test(testRxReadIsReadonly).runAtPath { try DatabasePool(path: $0).makeSnapshot() }
-    }
-    
-    func testRxReadIsReadonly<Reader: DatabaseReader & ReactiveCompatible>(reader: Reader, disposeBag: DisposeBag) throws {
-        let single = reader.rx.read { db in
-            try Player.createTable(db)
-        }
-        
-        let sequence = single
-            .asObservable()
-            .toBlocking(timeout: 1)
-            .materialize()
-        switch sequence {
-        case .completed:
-            XCTFail("Expected error")
-        case let .failed(elements: elements, error: error):
-            XCTAssertTrue(elements.isEmpty)
-            guard let dbError = error as? DatabaseError else {
-                XCTFail("Unexpected error: \(error)")
-                return
+        func test(reader: DatabaseReader, disposeBag: DisposeBag) throws {
+            let semaphore = DispatchSemaphore(value: 0)
+            let single = reader.rx.read { db -> Int in
+                // Make sure this block executes asynchronously
+                semaphore.wait()
+                return try Player.fetchCount(db)
             }
-            XCTAssertEqual(dbError.resultCode, .SQLITE_READONLY)
+            
+            let count = try single
+                .asObservable()
+                .do(onSubscribed: {
+                    semaphore.signal()
+                })
+                .toBlocking(timeout: 1)
+                .single()
+            XCTAssertEqual(count, 1)
         }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)).makeSnapshot() }
+    }
+    
+    func testRxReadIsReadonly() throws {
+        func test(reader: DatabaseReader, disposeBag: DisposeBag) throws {
+            let single = reader.rx.read { db in
+                try Player.createTable(db)
+            }
+            
+            let sequence = single
+                .asObservable()
+                .toBlocking(timeout: 1)
+                .materialize()
+            switch sequence {
+            case .completed:
+                XCTFail("Expected error")
+            case let .failed(elements: elements, error: error):
+                XCTAssertTrue(elements.isEmpty)
+                guard let dbError = error as? DatabaseError else {
+                    XCTFail("Unexpected error: \(error)")
+                    return
+                }
+                XCTAssertEqual(dbError.resultCode, .SQLITE_READONLY)
+            }
+        }
+        
+        try Test(test)
+            .run { DatabaseQueue() }
+            .runAtPath { try DatabaseQueue(path: $0) }
+            .runAtPath { try DatabasePool(path: $0) }
+            .runAtPath { try DatabasePool(path: $0).makeSnapshot() }
     }
 }

--- a/Tests/DatabaseWriterWriteAndReturnTests.swift
+++ b/Tests/DatabaseWriterWriteAndReturnTests.swift
@@ -18,118 +18,117 @@ private struct Player: Codable, FetchableRecord, PersistableRecord {
     }
 }
 
-class DatabaseWriterWriteAndReturnTests : XCTestCase { }
-
-extension DatabaseWriterWriteAndReturnTests {
+class DatabaseWriterWriteAndReturnTests : XCTestCase {
     func testRxWriteAndReturn() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write(Player.createTable)
             return writer
         }
-        try Test(testRxWriteAndReturn).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteAndReturn).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteAndReturn).runAtPath { try setup(DatabasePool(path: $0)) }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single = writer.rx.writeAndReturn { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+            }
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            let _: Void = try single.toBlocking(timeout: 1).single()
+            try XCTAssertEqual(writer.read(Player.fetchCount), 1)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
-    func testRxWriteAndReturn<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let single = writer.rx.writeAndReturn { db in
-            try Player(id: 1, name: "Arthur", score: 1000).insert(db)
-        }
-        try XCTAssertEqual(writer.read(Player.fetchCount), 0)
-        let _: Void = try single.toBlocking(timeout: 1).single()
-        try XCTAssertEqual(writer.read(Player.fetchCount), 1)
-    }
-}
-
-extension DatabaseWriterWriteAndReturnTests {
     func testRxWriteAndReturnValue() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write(Player.createTable)
             return writer
         }
-        try Test(testRxWriteAndReturnValue).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteAndReturnValue).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteAndReturnValue).runAtPath { try setup(DatabasePool(path: $0)) }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single = writer.rx.writeAndReturn { db -> Int in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                return try Player.fetchCount(db)
+            }
+            let count = try single.toBlocking(timeout: 1).single()
+            XCTAssertEqual(count, 1)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
-    func testRxWriteAndReturnValue<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let single = writer.rx.writeAndReturn { db -> Int in
-            try Player(id: 1, name: "Arthur", score: 1000).insert(db)
-            return try Player.fetchCount(db)
-        }
-        let count = try single.toBlocking(timeout: 1).single()
-        XCTAssertEqual(count, 1)
-    }
-}
-
-extension DatabaseWriterWriteAndReturnTests {
     func testRxWriteAndReturnScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
-            func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+            func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
                 try writer.write { db in
                     try Player.createTable(db)
                 }
                 return writer
             }
-            try Test(testRxWriteAndReturnScheduler).run { try setup(DatabaseQueue()) }
-            try Test(testRxWriteAndReturnScheduler).runAtPath { try setup(DatabaseQueue(path: $0)) }
-            try Test(testRxWriteAndReturnScheduler).runAtPath { try setup(DatabasePool(path: $0)) }
+            
+            func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+                do {
+                    let single = writer.rx
+                        .writeAndReturn { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) }
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(.main))
+                        })
+                    _ = try single.toBlocking(timeout: 1).single()
+                }
+                do {
+                    let queue = DispatchQueue(label: "test")
+                    let single = writer.rx
+                        .writeAndReturn(
+                            observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
+                            updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) })
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(queue))
+                        })
+                    _ = try single.toBlocking(timeout: 1).single()
+                }
+            }
+            
+            try Test(test)
+                .run { try setup(DatabaseQueue()) }
+                .runAtPath { try setup(DatabaseQueue(path: $0)) }
+                .runAtPath { try setup(DatabasePool(path: $0)) }
         }
     }
     
-    @available(OSX 10.12, iOS 10.0, watchOS 3.0, *)
-    func testRxWriteAndReturnScheduler<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        do {
-            let single = writer.rx
-                .writeAndReturn { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) }
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(.main))
-                })
-            _ = try single.toBlocking(timeout: 1).single()
-        }
-        do {
-            let queue = DispatchQueue(label: "test")
-            let single = writer.rx
-                .writeAndReturn(
-                    observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
-                    updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) })
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                })
-            _ = try single.toBlocking(timeout: 1).single()
-        }
-    }
-}
-
-extension DatabaseWriterWriteAndReturnTests {
     func testRxWriteAndReturnIsAsynchronous() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write { db in
                 try Player.createTable(db)
             }
             return writer
         }
-        try Test(testRxWriteAndReturnIsAsynchronous).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteAndReturnIsAsynchronous).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteAndReturnIsAsynchronous).runAtPath { try setup(DatabasePool(path: $0)) }
-    }
-    
-    func testRxWriteAndReturnIsAsynchronous<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let semaphore = DispatchSemaphore(value: 0)
-        let single = writer.rx.writeAndReturn { db -> Int in
-            // Make sure this block executes asynchronously
-            semaphore.wait()
-            try Player(id: 1, name: "Arthur", score: 1000).insert(db)
-            return try Player.fetchCount(db)
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let semaphore = DispatchSemaphore(value: 0)
+            let single = writer.rx.writeAndReturn { db -> Int in
+                // Make sure this block executes asynchronously
+                semaphore.wait()
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                return try Player.fetchCount(db)
+            }
+            
+            let count = try single
+                .asObservable()
+                .do(onSubscribed: {
+                    semaphore.signal()
+                })
+                .toBlocking(timeout: 1)
+                .single()
+            XCTAssertEqual(count, 1)
         }
         
-        let count = try single
-            .asObservable()
-            .do(onSubscribed: {
-                semaphore.signal()
-            })
-            .toBlocking(timeout: 1)
-            .single()
-        XCTAssertEqual(count, 1)
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
 }

--- a/Tests/DatabaseWriterWriteTests.swift
+++ b/Tests/DatabaseWriterWriteTests.swift
@@ -18,94 +18,93 @@ private struct Player: Codable, FetchableRecord, PersistableRecord {
     }
 }
 
-class DatabaseWriterWriteTests : XCTestCase { }
-
-extension DatabaseWriterWriteTests {
+class DatabaseWriterWriteTests : XCTestCase {
     func testRxWrite() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write(Player.createTable)
             return writer
         }
-        try Test(testRxWrite).run { try setup(DatabaseQueue()) }
-        try Test(testRxWrite).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWrite).runAtPath { try setup(DatabasePool(path: $0)) }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let completable = writer.rx.write { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+            }
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            _ = try completable.toBlocking(timeout: 1).toArray()
+            try XCTAssertEqual(writer.read(Player.fetchCount), 1)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
-    func testRxWrite<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let completable = writer.rx.write { db in
-            try Player(id: 1, name: "Arthur", score: 1000).insert(db)
-        }
-        try XCTAssertEqual(writer.read(Player.fetchCount), 0)
-        _ = try completable.toBlocking(timeout: 1).toArray()
-        try XCTAssertEqual(writer.read(Player.fetchCount), 1)
-    }
-}
-
-extension DatabaseWriterWriteTests {
     func testRxWriteScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
-            func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+            func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
                 try writer.write { db in
                     try Player.createTable(db)
                 }
                 return writer
             }
-            try Test(testRxWriteScheduler).run { try setup(DatabaseQueue()) }
-            try Test(testRxWriteScheduler).runAtPath { try setup(DatabaseQueue(path: $0)) }
-            try Test(testRxWriteScheduler).runAtPath { try setup(DatabasePool(path: $0)) }
+            
+            func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+                do {
+                    let completable = writer.rx
+                        .write { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) }
+                        .do(onCompleted: {
+                            dispatchPrecondition(condition: .onQueue(.main))
+                        })
+                    _ = try completable.toBlocking(timeout: 1).toArray()
+                }
+                do {
+                    let queue = DispatchQueue(label: "test")
+                    let completable = writer.rx
+                        .write(
+                            observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
+                            updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) })
+                        .do(onCompleted: {
+                            dispatchPrecondition(condition: .onQueue(queue))
+                        })
+                    _ = try completable.toBlocking(timeout: 1).toArray()
+                }
+            }
+            
+            try Test(test)
+                .run { try setup(DatabaseQueue()) }
+                .runAtPath { try setup(DatabaseQueue(path: $0)) }
+                .runAtPath { try setup(DatabasePool(path: $0)) }
         }
     }
     
-    @available(OSX 10.12, iOS 10.0, watchOS 3.0, *)
-    func testRxWriteScheduler<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        do {
-            let completable = writer.rx
-                .write { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) }
-                .do(onCompleted: {
-                    dispatchPrecondition(condition: .onQueue(.main))
-                })
-            _ = try completable.toBlocking(timeout: 1).toArray()
-        }
-        do {
-            let queue = DispatchQueue(label: "test")
-            let completable = writer.rx
-                .write(
-                    observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
-                    updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) })
-                .do(onCompleted: {
-                    dispatchPrecondition(condition: .onQueue(queue))
-                })
-            _ = try completable.toBlocking(timeout: 1).toArray()
-        }
-    }
-}
-
-extension DatabaseWriterWriteTests {
     func testRxWriteIsAsynchronous() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write { db in
                 try Player.createTable(db)
             }
             return writer
         }
-        try Test(testRxWriteIsAsynchronous).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteIsAsynchronous).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteIsAsynchronous).runAtPath { try setup(DatabasePool(path: $0)) }
-    }
-    
-    func testRxWriteIsAsynchronous<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let semaphore = DispatchSemaphore(value: 0)
-        let completable = writer.rx.write { db in
-            // Make sure this block executes asynchronously
-            semaphore.wait()
-            try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let semaphore = DispatchSemaphore(value: 0)
+            let completable = writer.rx.write { db in
+                // Make sure this block executes asynchronously
+                semaphore.wait()
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+            }
+            
+            _ = try completable
+                .do(onSubscribed: {
+                    semaphore.signal()
+                })
+                .toBlocking(timeout: 1)
+                .toArray()
         }
         
-        _ = try completable
-            .do(onSubscribed: {
-                semaphore.signal()
-            })
-            .toBlocking(timeout: 1)
-            .toArray()
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
 }

--- a/Tests/DatabaseWriterWriteThenReadTests.swift
+++ b/Tests/DatabaseWriterWriteThenReadTests.swift
@@ -18,121 +18,133 @@ private struct Player: Codable, FetchableRecord, PersistableRecord {
     }
 }
 
-class DatabaseWriterWriteThenReadTests : XCTestCase { }
-
-extension DatabaseWriterWriteThenReadTests {
+class DatabaseWriterWriteThenReadTests : XCTestCase {
+    func testRxJoiner() {
+        // Make sure `rx` joiner is available in various contexts
+        func f1(_ writer: DatabasePool) {
+            _ = writer.rx.write(updates: { db in })
+        }
+        func f2(_ writer: DatabaseQueue) {
+            _ = writer.rx.write(updates: { db in })
+        }
+        func f3<Writer: DatabaseWriter>(_ writer: Writer) {
+            _ = writer.rx.write(updates: { db in })
+        }
+        func f4(_ writer: DatabaseWriter) {
+            _ = writer.rx.write(updates: { db in })
+        }
+    }
+    
     func testRxWriteThenRead() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write(Player.createTable)
             return writer
         }
-        try Test(testRxWriteThenRead).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteThenRead).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteThenRead).runAtPath { try setup(DatabasePool(path: $0)) }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single: Single<Int> = writer.rx.write(
+                updates: { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) },
+                thenRead: { (db, _) in try Player.fetchCount(db) })
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            let count = try single.toBlocking(timeout: 1).single()
+            XCTAssertEqual(count, 1)
+        }
+        
+        try Test(test).run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
-    func testRxWriteThenRead<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let single: Single<Int> = writer.rx.write(
-            updates: { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) },
-            thenRead: { (db, _) in try Player.fetchCount(db) })
-        try XCTAssertEqual(writer.read(Player.fetchCount), 0)
-        let count = try single.toBlocking(timeout: 1).single()
-        XCTAssertEqual(count, 1)
-    }
-}
-
-extension DatabaseWriterWriteThenReadTests {
     func testRxWriteValueThenRead() throws {
-        func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
             try writer.write(Player.createTable)
             return writer
         }
-        try Test(testRxWriteValueThenRead).run { try setup(DatabaseQueue()) }
-        try Test(testRxWriteValueThenRead).runAtPath { try setup(DatabaseQueue(path: $0)) }
-        try Test(testRxWriteValueThenRead).runAtPath { try setup(DatabasePool(path: $0)) }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single: Single<Int> = writer.rx.write(
+                updates: { db -> Int in
+                    try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                    return 42
+            },
+                thenRead: { (db, int) in try int + Player.fetchCount(db) })
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            let count = try single.toBlocking(timeout: 1).single()
+            XCTAssertEqual(count, 43)
+        }
+        
+        try Test(test).run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
-    func testRxWriteValueThenRead<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let single: Single<Int> = writer.rx.write(
-            updates: { db -> Int in
-                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
-                return 42
-        },
-            thenRead: { (db, int) in try int + Player.fetchCount(db) })
-        try XCTAssertEqual(writer.read(Player.fetchCount), 0)
-        let count = try single.toBlocking(timeout: 1).single()
-        XCTAssertEqual(count, 43)
-    }
-}
-
-extension DatabaseWriterWriteThenReadTests {
     func testRxWriteThenReadScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
-            func setup<Writer: DatabaseWriter & ReactiveCompatible>(_ writer: Writer) throws -> Writer {
+            func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
                 try writer.write { db in
                     try Player.createTable(db)
                 }
                 return writer
             }
-            try Test(testRxWriteThenReadScheduler).run { try setup(DatabaseQueue()) }
-            try Test(testRxWriteThenReadScheduler).runAtPath { try setup(DatabaseQueue(path: $0)) }
-            try Test(testRxWriteThenReadScheduler).runAtPath { try setup(DatabasePool(path: $0)) }
-        }
-    }
-    
-    @available(OSX 10.12, iOS 10.0, watchOS 3.0, *)
-    func testRxWriteThenReadScheduler<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        do {
-            let single = writer.rx
-                .write(
-                    updates: { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) },
-                    thenRead: { (db, _) in try Player.fetchCount(db) })
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(.main))
-                })
-            _ = try single.toBlocking(timeout: 1).single()
-        }
-        do {
-            let queue = DispatchQueue(label: "test")
-            let single = writer.rx
-                .write(
-                    observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
-                    updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) },
-                    thenRead: { (db, _) in try Player.fetchCount(db) })
-                .do(onSuccess: { _ in
-                    dispatchPrecondition(condition: .onQueue(queue))
-                })
-            _ = try single.toBlocking(timeout: 1).single()
-        }
-    }
-}
-
-extension DatabaseWriterWriteThenReadTests {
-    func testRxWriteThenReadIsReadOnly() throws {
-        try Test(testRxWriteThenReadIsReadOnly).run { DatabaseQueue() }
-        try Test(testRxWriteThenReadIsReadOnly).runAtPath { try DatabaseQueue(path: $0) }
-        try Test(testRxWriteThenReadIsReadOnly).runAtPath { try DatabasePool(path: $0) }
-    }
-    
-    func testRxWriteThenReadIsReadOnly<Writer: DatabaseWriter & ReactiveCompatible>(writer: Writer, disposeBag: DisposeBag) throws {
-        let single = writer.rx.write(
-            updates: { _ in },
-            thenRead: { (db, _) in try Player.createTable(db) })
-        
-        let sequence = single
-            .asObservable()
-            .toBlocking(timeout: 1)
-            .materialize()
-        switch sequence {
-        case .completed:
-            XCTFail("Expected error")
-        case let .failed(elements: elements, error: error):
-            XCTAssertTrue(elements.isEmpty)
-            guard let dbError = error as? DatabaseError else {
-                XCTFail("Unexpected error: \(error)")
-                return
+            
+            func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+                do {
+                    let single = writer.rx
+                        .write(
+                            updates: { db in try Player(id: 1, name: "Arthur", score: 1000).insert(db) },
+                            thenRead: { (db, _) in try Player.fetchCount(db) })
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(.main))
+                        })
+                    _ = try single.toBlocking(timeout: 1).single()
+                }
+                do {
+                    let queue = DispatchQueue(label: "test")
+                    let single = writer.rx
+                        .write(
+                            observeOn: SerialDispatchQueueScheduler(queue: queue, internalSerialQueueName: "test"),
+                            updates: { db in try Player(id: 2, name: "Barbara", score: nil).insert(db) },
+                            thenRead: { (db, _) in try Player.fetchCount(db) })
+                        .do(onSuccess: { _ in
+                            dispatchPrecondition(condition: .onQueue(queue))
+                        })
+                    _ = try single.toBlocking(timeout: 1).single()
+                }
             }
-            XCTAssertEqual(dbError.resultCode, .SQLITE_READONLY)
+            
+            try Test(test)
+                .run { try setup(DatabaseQueue()) }
+                .runAtPath { try setup(DatabaseQueue(path: $0)) }
+                .runAtPath { try setup(DatabasePool(path: $0)) }
         }
+    }
+    
+    func testRxWriteThenReadIsReadOnly() throws {
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single = writer.rx.write(
+                updates: { _ in },
+                thenRead: { (db, _) in try Player.createTable(db) })
+            
+            let sequence = single
+                .asObservable()
+                .toBlocking(timeout: 1)
+                .materialize()
+            switch sequence {
+            case .completed:
+                XCTFail("Expected error")
+            case let .failed(elements: elements, error: error):
+                XCTAssertTrue(elements.isEmpty)
+                guard let dbError = error as? DatabaseError else {
+                    XCTFail("Unexpected error: \(error)")
+                    return
+                }
+                XCTAssertEqual(dbError.resultCode, .SQLITE_READONLY)
+            }
+        }
+        
+        try Test(test)
+            .run { DatabaseQueue() }
+            .runAtPath { try DatabaseQueue(path: $0) }
+            .runAtPath { try DatabasePool(path: $0) }
     }
 }


### PR DESCRIPTION
Until this PR, the `rx` reactive joiner was available on concrete databases, but not on DatabaseReader and DatabaseWriter existentials:

```swift
// OK
let dbQueue: DatabaseQueue = ...
dbQueue.rx.read { ... )

// Compiler error
let writer: DatabaseWriter = ...
writer.rx.read { ... )
```

Because of this limitation, it was uneasy to write code which accepts both DatabasePool and DatabaseQueue.

This PR fixes this:

```swift
// OK as well
let writer: DatabaseWriter = ...
writer.rx.read { ... )
```
