### PR TITLE
Fix error handling of asynchronous writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Release Notes
 ## Next Version
 
 - [#60](https://github.com/RxSwiftCommunity/RxGRDB/pull/60) by [@sammygutierrez](https://github.com/sammygutierrez): Add SwiftPM support
+- [#61](https://github.com/RxSwiftCommunity/RxGRDB/pull/61): Fix error handling of asynchronous writes
 
 
 ## 0.17.0

--- a/RxGRDB/DatabaseWriter+Rx.swift
+++ b/RxGRDB/DatabaseWriter+Rx.swift
@@ -85,12 +85,8 @@ extension Reactive where Base: DatabaseWriter {
         return flatMapWrite(
             observeOn: scheduler,
             updates: { db in
-                do {
-                    try updates(db)
-                    return .empty()
-                } catch {
-                    return .error(error)
-                }
+                try updates(db)
+                return .empty()
         })
             .asCompletable()
     }
@@ -115,13 +111,7 @@ extension Reactive where Base: DatabaseWriter {
     {
         return flatMapWrite(
             observeOn: scheduler,
-            updates: { db in
-                do {
-                    return try .just(updates(db))
-                } catch {
-                    return .error(error)
-                }
-        })
+            updates: { db in try .just(updates(db)) })
             .asSingle()
     }
     

--- a/Tests/DatabaseWriterWriteAndReturnTests.swift
+++ b/Tests/DatabaseWriterWriteAndReturnTests.swift
@@ -61,6 +61,35 @@ class DatabaseWriterWriteAndReturnTests : XCTestCase {
             .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
+    func testRxWriteAndReturnError() throws {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let single = writer.rx.writeAndReturn { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                try db.execute(sql: "THIS IS NOT SQL")
+            }
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            do {
+                _ = try single.toBlocking(timeout: 1).single()
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.sql, "THIS IS NOT SQL")
+            }
+            // Transaction has been rollbacked
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
+    }
+    
     func testRxWriteAndReturnScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
             func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {

--- a/Tests/DatabaseWriterWriteTests.swift
+++ b/Tests/DatabaseWriterWriteTests.swift
@@ -40,6 +40,35 @@ class DatabaseWriterWriteTests : XCTestCase {
             .runAtPath { try setup(DatabasePool(path: $0)) }
     }
     
+    func testRxWriteError() throws {
+        func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: DatabaseWriter, disposeBag: DisposeBag) throws {
+            let completable = writer.rx.write { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                try db.execute(sql: "THIS IS NOT SQL")
+            }
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            do {
+                _ = try completable.toBlocking(timeout: 1).toArray()
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.sql, "THIS IS NOT SQL")
+            }
+            // Transaction has been rollbacked
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+        }
+        
+        try Test(test)
+            .run { try setup(DatabaseQueue()) }
+            .runAtPath { try setup(DatabaseQueue(path: $0)) }
+            .runAtPath { try setup(DatabasePool(path: $0)) }
+    }
+    
     func testRxWriteScheduler() throws {
         if #available(OSX 10.12, iOS 10.0, watchOS 3.0, *) {
             func setup<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {


### PR DESCRIPTION
This pull request fixes a bug in the error handling of asynchronous writes.

They did not rollback the asynchronous transaction in case of error 😕.