### PR TITLE
Update RxGRDB1MigrationGuide.md

### DIFF
--- a/Documentation/RxGRDB1MigrationGuide.md
+++ b/Documentation/RxGRDB1MigrationGuide.md
@@ -100,8 +100,9 @@ RxGRDB 1.0 comes with breaking changes. Those changes have the vanilla [GRDB], [
     Other former ways to observe the database are no longer available:
     
     ```swift
-    // BEFORE: RxGRDB 0.x
     let request = Player.all()
+
+    // BEFORE: RxGRDB 0.x
     request.rx.observeCount(in: dbQueue) // Observable<Int>
     request.rx.observeFirst(in: dbQueue) // Observable<Player?>
     request.rx.observeAll(in: dbQueue)   // Observable<[Player]>


### PR DESCRIPTION
It looks as if request is used in both code examples, so it might be better to put it before the before part to make this more clear.