### PR TITLE
Support for GRDB 7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "RxGRDB", targets: ["RxGRDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "7.0.0")),
+        .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "7.1.0")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -5,16 +5,16 @@ import PackageDescription
 let package = Package(
     name: "RxGRDB",
     platforms: [
-        .iOS(.v11),
-        .macOS(.v10_13),
-        .tvOS(.v11),
-        .watchOS(.v4),
+        .iOS(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v7),
     ],
     products: [
         .library(name: "RxGRDB", targets: ["RxGRDB"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "6.0.0")),
+        .package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMajor(from: "7.0.0")),
         .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0"))
     ],
     targets: [

--- a/Sources/RxGRDB/ValueObservation+Rx.swift
+++ b/Sources/RxGRDB/ValueObservation+Rx.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import GRDB
 import RxSwift
 


### PR DESCRIPTION
This pull request addresses #72 by bumping the minimum GRDB version to 7.1.

@foxware00, @Lutzifer, I could merge right away, but maybe you'd prefer to giving this branch a test first.

Don't miss the [Migrating From GRDB 6 to GRDB 7](https://github.com/groue/GRDB.swift/blob/master/Documentation/GRDB7MigrationGuide.md) guide.