### PR TITLE
refactor: Replace deprecated API methods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,5 +32,5 @@ let package = Package(
                 .product(name: "RxBlocking", package: "RxSwift"),
             ])
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v5]
 )


### PR DESCRIPTION
Hello 👋

This PR updates the **`Package.swift`** file to replace the deprecated `swiftLanguageVersions` parameter with the `swiftLanguageModes` parameter.

#trivial

## Changes
- Replaced `swiftLanguageVersions: [.v5]` with `swiftLanguageModes: [.v5]`